### PR TITLE
Issue 48 - Use high resolution assets when possible

### DIFF
--- a/blocks/aem-asset-selector/aem-asset-selector-util.js
+++ b/blocks/aem-asset-selector/aem-asset-selector-util.js
@@ -254,10 +254,10 @@ async function loadImageIntoHtmlElement(url) {
  * @param {*} targetMimeType Target mimetype (target format)
  * @returns A conversion promise resolving to a blob of the target mimetype
  */
-async function convertImage(assetPublicUrl, targetMimeType='image/png', asset) {
+async function convertImage(assetPublicUrl, targetMimeType, asset) {
   const imageElement = await loadImageIntoHtmlElement(assetPublicUrl);
 
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     const canvas = document.createElement('canvas');
     canvas.width = asset['tiff:imageWidth'];
     canvas.height = asset['tiff:imageLength'];

--- a/blocks/aem-asset-selector/aem-asset-selector-util.js
+++ b/blocks/aem-asset-selector/aem-asset-selector-util.js
@@ -213,10 +213,6 @@ function getCopyRendition(asset) {
         maxRendition = rendition;
       }
     });
-
-  console.log("~~~~~~~~~ Picked rendition: ")
-  console.log(maxRendition)
-  console.log("~~~~~~~~~  ")
   return maxRendition;
 }
 
@@ -259,10 +255,8 @@ async function loadImageIntoHtmlElement(url) {
  * @returns A conversion promise resolving to a blob of the target mimetype
  */
 async function convertImage(assetPublicUrl, targetMimeType='image/png', asset) {
-  const main = document.querySelector('main');
   const imageElement = await loadImageIntoHtmlElement(assetPublicUrl);
 
-  console.log('## convertImage: ', assetPublicUrl)
   return new Promise(resolve => {
     const canvas = document.createElement('canvas');
     canvas.width = asset['tiff:imageWidth'];
@@ -284,8 +278,7 @@ async function convertImage(assetPublicUrl, targetMimeType='image/png', asset) {
  */
 async function copyToClipboardWithBinary(assetPublicUrl, mimeType, asset) {
   let data;
-  console.log("## copyToClipboardWithBinary")
-  console.log(mimeType);
+
   if (!CLIPBOARD_SUPPORTED_BINARY_MIMETYPES.includes(mimeType)) {
     const copiedBlob = await convertImage(assetPublicUrl, 'image/png', asset);
 
@@ -368,7 +361,7 @@ export async function copyAssetWithRapi(asset) {
   }
   const download = getRel(rendition, REL_DOWNLOAD);
   if (!download || !download.href) {
-    console.log('Rendition does not contain sufficient information');
+    logMessage('Rendition does not contain sufficient information');
     return false;
   }
   try {
@@ -379,17 +372,17 @@ export async function copyAssetWithRapi(asset) {
       },
     });
     if (!res.ok) {
-      console.log(`Download request for rendition binary failed with status code ${res.status}: ${res.statusText}`);
+      logMessage(`Download request for rendition binary failed with status code ${res.status}: ${res.statusText}`);
       return false;
     }
     const downloadJson = await res.json();
     if (!downloadJson) {
-      console.log('Rendition download JSON not provided');
+      logMessage('Rendition download JSON not provided');
       return false;
     }
     await copyToClipboardWithBinary(downloadJson.href, downloadJson.type, asset);
   } catch (e) {
-    console.log('Error copying asset using R-API to clipboard', e);
+    logMessage('Error copying asset using R-API to clipboard', e);
     return false;
   }
 

--- a/blocks/aem-asset-selector/aem-asset-selector-util.js
+++ b/blocks/aem-asset-selector/aem-asset-selector-util.js
@@ -254,10 +254,10 @@ async function loadImageIntoHtmlElement(url) {
  * @param {*} targetMimeType Target mimetype (target format)
  * @returns A conversion promise resolving to a blob of the target mimetype
  */
-async function convertImage(assetPublicUrl, targetMimeType, asset) {
+async function convertImage(assetPublicUrl, targetMimeType='image/png', asset) {
   const imageElement = await loadImageIntoHtmlElement(assetPublicUrl);
 
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     const canvas = document.createElement('canvas');
     canvas.width = asset['tiff:imageWidth'];
     canvas.height = asset['tiff:imageLength'];
@@ -277,16 +277,12 @@ async function convertImage(assetPublicUrl, targetMimeType, asset) {
  * @returns {Promise} Resolves when the item has been written to the clipboard.
  */
 async function copyToClipboardWithBinary(assetPublicUrl, mimeType, asset) {
-  let data;
+  let clipboardOptions = {};
 
   if (!CLIPBOARD_SUPPORTED_BINARY_MIMETYPES.includes(mimeType)) {
-    const copiedBlob = await convertImage(assetPublicUrl, 'image/png', asset);
-
-    const clipboardOptions = {};
-    clipboardOptions['image/png'] = copiedBlob;
-    data = [
-      new ClipboardItem(clipboardOptions),
-    ];
+    const clipboardTargetMimetype = 'image/png';
+    const copiedBlob = await convertImage(assetPublicUrl, clipboardTargetMimetype, asset);
+    clipboardOptions[clipboardTargetMimetype] = copiedBlob;
   } else {
     const binary = await fetch(assetPublicUrl);
 
@@ -298,13 +294,12 @@ async function copyToClipboardWithBinary(assetPublicUrl, mimeType, asset) {
     if (!blob) {
       throw new Error('No blob provided in asset response');
     }
-
-    const clipboardOptions = {};
     clipboardOptions[mimeType] = blob;
-    data = [
-      new ClipboardItem(clipboardOptions),
-    ];
   }
+
+  const data = [
+    new ClipboardItem(clipboardOptions),
+  ];
 
   return navigator.clipboard.write(data);
 }

--- a/blocks/aem-asset-selector/aem-asset-selector-util.js
+++ b/blocks/aem-asset-selector/aem-asset-selector-util.js
@@ -254,10 +254,10 @@ async function loadImageIntoHtmlElement(url) {
  * @param {*} targetMimeType Target mimetype (target format)
  * @returns A conversion promise resolving to a blob of the target mimetype
  */
-async function convertImage(assetPublicUrl, targetMimeType='image/png', asset) {
+async function convertImage(assetPublicUrl, targetMimeType, asset) {
   const imageElement = await loadImageIntoHtmlElement(assetPublicUrl);
 
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     const canvas = document.createElement('canvas');
     canvas.width = asset['tiff:imageWidth'];
     canvas.height = asset['tiff:imageLength'];
@@ -277,7 +277,7 @@ async function convertImage(assetPublicUrl, targetMimeType='image/png', asset) {
  * @returns {Promise} Resolves when the item has been written to the clipboard.
  */
 async function copyToClipboardWithBinary(assetPublicUrl, mimeType, asset) {
-  let clipboardOptions = {};
+  const clipboardOptions = {};
 
   if (!CLIPBOARD_SUPPORTED_BINARY_MIMETYPES.includes(mimeType)) {
     const clipboardTargetMimetype = 'image/png';


### PR DESCRIPTION
Fix https://github.com/hlxsites/franklin-assets-selector/issues/48

Allows higher resolution selections by allowing more mimetypes to be picked as the rendition to use than only PNG.
When a JPEG asset is picked, it is converted into a PNG blog using a canvas.

Currently only JPEG and PNG mimetypes are supported, but the list can be extended in the future as the support for image conversion improves, and once we test and validate that it works.

