### PR TITLE
Simplify logging

### DIFF
--- a/blocks/aem-asset-selector/aem-asset-selector-util.js
+++ b/blocks/aem-asset-selector/aem-asset-selector-util.js
@@ -75,16 +75,6 @@ let imsInstance = null;
 let imsEnvironment = IMS_ENV_PROD;
 
 /**
- * Logs a message to the console.
- * @param  {...any} theArgs Arguments to pass to the console log
- *  statement.
- */
-function logMessage(...theArgs) {
-  // eslint-disable-next-line no-console
-  console.log.apply(null, theArgs);
-}
-
-/**
  * Retrieves the value of a rel from repository metadata.
  * @param {Asset|Rendition} repositoryMetadata Metadata whose links
  *  will be used.
@@ -317,18 +307,18 @@ async function copyToClipboardWithBinary(assetPublicUrl, mimeType, asset) {
 export async function copyAssetWithoutRapi(asset) {
   const maxRendition = getCopyRendition(asset);
   if (!maxRendition) {
-    logMessage('No rendition to copy found');
+    console.log('No rendition to copy found');
     return false;
   }
   try {
     const assetPublicUrl = await getAssetPublicUrl(maxRendition.href.substring(0, maxRendition.href.indexOf('?')));
     if (!assetPublicUrl) {
-      logMessage('Unable to generate public url for copy');
+      console.log('Unable to generate public url for copy');
       return false;
     }
     await copyToClipboardWithHtml(assetPublicUrl);
   } catch (e) {
-    logMessage('Error copying asset to clipboard', e);
+    console.log('Error copying asset to clipboard', e);
     return false;
   }
   return true;
@@ -346,17 +336,17 @@ export async function copyAssetWithoutRapi(asset) {
 export async function copyAssetWithRapi(asset) {
   // eslint-disable-next-line no-underscore-dangle
   if (!asset) {
-    logMessage('Asset metadata does not contain sufficient information');
+    console.log('Asset metadata does not contain sufficient information');
     return false;
   }
   const rendition = getCopyRendition(asset);
   if (!rendition) {
-    logMessage('No rendition to copy found');
+    console.log('No rendition to copy found');
     return false;
   }
   const download = getRel(rendition, REL_DOWNLOAD);
   if (!download || !download.href) {
-    logMessage('Rendition does not contain sufficient information');
+    console.log('Rendition does not contain sufficient information');
     return false;
   }
   try {
@@ -367,17 +357,17 @@ export async function copyAssetWithRapi(asset) {
       },
     });
     if (!res.ok) {
-      logMessage(`Download request for rendition binary failed with status code ${res.status}: ${res.statusText}`);
+      console.log(`Download request for rendition binary failed with status code ${res.status}: ${res.statusText}`);
       return false;
     }
     const downloadJson = await res.json();
     if (!downloadJson) {
-      logMessage('Rendition download JSON not provided');
+      console.log('Rendition download JSON not provided');
       return false;
     }
     await copyToClipboardWithBinary(downloadJson.href, downloadJson.type, asset);
   } catch (e) {
-    logMessage('Error copying asset using R-API to clipboard', e);
+    console.log('Error copying asset using R-API to clipboard', e);
     return false;
   }
 
@@ -403,7 +393,7 @@ function handleAssetSelection(selection, cfg) {
   if (cfg) {
     if (selection.length && cfg.onAssetSelected) {
       if (selection.length > 1) {
-        logMessage('Multiple items received in selection, but only the first will be used');
+        console.log('Multiple items received in selection, but only the first will be used');
       }
       cfg.onAssetSelected(selection[0]);
     } else if (!selection.length && cfg.onAssetDeselected) {

--- a/blocks/aem-asset-selector/aem-asset-selector-util.js
+++ b/blocks/aem-asset-selector/aem-asset-selector-util.js
@@ -10,6 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+/* eslint-disable no-console */
+
 /**
  * @typedef Links
  */


### PR DESCRIPTION
Removes a level of indirection to have shorter stacktraces and log messages in the browser dev tools.
Also, this will make the files+lines pointed by errors clickable again and move to the error/log source.

Test URLs:

Before: https://main--franklin-assets-selector--hlxsites.hlx.live/aem-asset-selector
After: https://refactor--franklin-assets-selector--hlxsites.hlx.live/aem-asset-selector