### PR TITLE
HotSpot Block- Whitelist Domain and Prevent Xss attack

### DIFF
--- a/blocks/hotspot/hotspot.js
+++ b/blocks/hotspot/hotspot.js
@@ -23,10 +23,26 @@ export default function decorate(block) {
         contentContainer.appendChild(img);
       } else if (isVideoVariant) {
         const video = document.createElement('div');
-        video.innerHTML = `<div class="embed-default">
-            <iframe src=${content} from allow="encrypted-media" loading="lazy">
-            </iframe>
-            </div>`;
+        const allowedVideoDomains = ['youtube.com', 'vimeo.com', 'sidekick-library--aem-block-collection--adobe'];
+        try {
+          const url = new URL(content);
+          //the below code can be updated to include more video hosting sites
+          const isTrustedDomain = allowedVideoDomains.some((domain) => url.hostname.includes(domain));
+          if (isTrustedDomain) {
+            video.innerHTML = `
+        <div class="embed-default">
+          <iframe src="${url.href}" allow="encrypted-media" loading="lazy">
+          </iframe>
+        </div>`;
+          } else {
+            console.warn('Untrusted video URL:', url.href);
+            video.textContent = 'This video source is not allowed.';
+            contentContainer.classList.add('bgborder');
+          }
+        } catch (e) {
+          console.error('Invalid video URL:', content);
+          video.textContent = 'Invalid video URL.';
+        }
         // above code can be updated for video controls such as autoplay, loop, etc.
         contentContainer.appendChild(video);
       } else if (isTextVariant) {

--- a/blocks/hotspot/hotspot.js
+++ b/blocks/hotspot/hotspot.js
@@ -30,17 +30,23 @@ export default function decorate(block) {
           const domainCheck = (domain) => url.hostname.includes(domain);
           const isTrustedDomain = allowedVideoDomains.some(domainCheck);
           if (isTrustedDomain) {
-            video.innerHTML = `
-        <div class="embed-default">
-          <iframe src="${url.href}" allow="encrypted-media" loading="lazy">
-          </iframe>
-        </div>`;
+            const div = document.createElement('div');
+            div.className = 'embed-default';
+
+            const iframe = document.createElement('iframe');
+            iframe.src = url.href;
+            iframe.setAttribute('allow', 'encrypted-media');
+            iframe.setAttribute('loading', 'lazy');
+
+            div.appendChild(iframe);
+            video.appendChild(div);
           } else {
             video.textContent = 'This video source is not allowed.';
             contentContainer.classList.add('bgborder');
           }
         } catch (e) {
           video.textContent = 'Invalid video URL.';
+          contentContainer.classList.add('bgborder');
         }
         // above code can be updated for video controls such as autoplay, loop, etc.
         contentContainer.appendChild(video);

--- a/blocks/hotspot/hotspot.js
+++ b/blocks/hotspot/hotspot.js
@@ -26,8 +26,9 @@ export default function decorate(block) {
         const allowedVideoDomains = ['youtube.com', 'vimeo.com', 'sidekick-library--aem-block-collection--adobe'];
         try {
           const url = new URL(content);
-          //the below code can be updated to include more video hosting sites
-          const isTrustedDomain = allowedVideoDomains.some((domain) => url.hostname.includes(domain));
+          // the below code can be updated to include more video hosting sites
+          const domainCheck = (domain) => url.hostname.includes(domain);
+          const isTrustedDomain = allowedVideoDomains.some(domainCheck);
           if (isTrustedDomain) {
             video.innerHTML = `
         <div class="embed-default">

--- a/blocks/hotspot/hotspot.js
+++ b/blocks/hotspot/hotspot.js
@@ -36,12 +36,10 @@ export default function decorate(block) {
           </iframe>
         </div>`;
           } else {
-            console.warn('Untrusted video URL:', url.href);
             video.textContent = 'This video source is not allowed.';
             contentContainer.classList.add('bgborder');
           }
         } catch (e) {
-          console.error('Invalid video URL:', content);
           video.textContent = 'Invalid video URL.';
         }
         // above code can be updated for video controls such as autoplay, loop, etc.


### PR DESCRIPTION
When isVideoVariant is true, the code creates a new URL object from the content string. This can help prevent XSS attacks because it ensures that the content string is a properly formatted URL. If it's not, an error will be thrown and caught, preventing any potentially malicious code from being executed. 

Additionally, the code checks if the hostname of the URL is included in a list of allowed video domains. This is another measure that can help prevent XSS attacks, as it restricts the sources of the videos to trusted domains

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--franklin-assets-selector--hlxsites.hlx.live/hotspot-block/hotspot
- After: https://hotspotblock--franklin-assets-selector--hlxsites.hlx.live/hotspot-block/hotspot
